### PR TITLE
Adding --rootdir to pytest call so that relative file names look right on stdout

### DIFF
--- a/build-support/make/core/python/test.mk
+++ b/build-support/make/core/python/test.mk
@@ -10,4 +10,5 @@ pytest:
 	$(eval targets := $(onpy))
 	$(eval marks := $(DEFAULT_PYTEST_MARKS))
 	if $(call lang,$(targets),$(REGEX_PY)); then \
-  	python -m coverage run -m pytest -m $(marks) $(PYTEST_FLAGS) $(targets) && python -m coverage html; fi
+  	python -m coverage run -m pytest --rootdir=. -m $(marks) $(PYTEST_FLAGS) $(targets) && python -m coverage html; fi
+


### PR DESCRIPTION
Was getting test names that begin with build-support/<path-to-pyproject.tom>/<path-to-test>